### PR TITLE
odyssey2: rename roms/o2em -> roms/odyssey

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -2475,7 +2475,7 @@
     <manufacturer>Magnavox - Philips</manufacturer>
     <release>1978</release>
     <hardware>console</hardware>
-    <path>~\..\roms\o2em</path>
+    <path>~\..\roms\odyssey2</path>
     <extension>.bin .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" -gameinfo %GAMEINFOXML% %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>


### PR DESCRIPTION
to match batocera recent change from
https://github.com/batocera-linux/batocera.linux/commit/ab447ae43a28d70a1db55f2d31fcea73de0fc4b1