### PR TITLE
snes-msu1 && sgb-msu1 : add .squashfs extensions support

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -1011,7 +1011,7 @@
     <hardware>extension</hardware>
     <release>2012</release>
     <path>~\..\roms\snes-msu1</path>
-    <extension>.smc .sfc .squashfs</extension>
+    <extension>.smc .sfc .squashfs .m3u</extension>
     <command>"%HOME%\emulatorLauncher.exe" -gameinfo %GAMEINFOXML% %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">


### PR DESCRIPTION
batocera already support .squashfs for snes-msu1 && sgb-msu1 since a long time.

This have to have a lof of files or directory by games.

This patch also remove .m3u && .bml extensions support for snes-msu1. (they are no multidisc games && .bml extension give duplicate roms  with .sfc|.smfc and need to be hidden manually currently)

depend of support in emulatorlauncher:
https://github.com/RetroBat-Official/emulatorlauncher/pull/1247

