### PR TITLE
Add emulationstation.exe to auto DPI-awareness override list

### DIFF
--- a/system/tools/dpi_awareness.txt
+++ b/system/tools/dpi_awareness.txt
@@ -1,3 +1,4 @@
+emulationstation\emulationstation.exe
 emulators\gsplus\gsplus.exe
 emulators\raine\raine.exe
 emulators\retroarch\retroarch.exe


### PR DESCRIPTION
## Summary
- RetroBat.exe already auto-applies the `HIGHDPIAWARE` compatibility override (via `system/tools/dpi_awareness.txt`, added in #210/#45) to a handful of standalone emulators so users don't have to set it manually.
- `emulationstation.exe` was missing from that list, so on 4K displays scaled above 100% (e.g. 125%/150%), users still had to manually enable "Override high DPI scaling" on EmulationStation for it to render/fullscreen correctly.
- Adds `emulationstation\emulationstation.exe` to the list so this now happens automatically like it does for RetroArch and the other listed emulators.

## Test plan
- [ ] Set Windows display scaling to >100% on a 4K display, delete any existing manual DPI compatibility override on `emulationstation.exe`, launch RetroBat, and confirm ES starts fullscreen/crisp without the manual override.